### PR TITLE
Ncnews task 11

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -92,6 +92,10 @@
   margin-bottom: 0.5em;
 }
 
+.comment-card-deleted {
+  opacity: 50%;
+}
+
 .comment-card.signed-in-user {
   background-color: lightgreen;
 }

--- a/src/components/CommentCard.js
+++ b/src/components/CommentCard.js
@@ -1,18 +1,27 @@
-import { useContext } from "react";
+import { useContext, useState } from "react";
 import { UserContext } from "../contexts/UserContext";
+import DeleteButton from "./DeleteButton";
 
 const CommentCard = ({ comment }) => {
+  const [isDeleted, setIsDeleted] = useState(false);
   const { signedInUser } = useContext(UserContext);
 
   return (
     <li
       className={`comment-card ${
         signedInUser === comment.author ? "signed-in-user" : null
-      }`}
+      } ${isDeleted ? "comment-card-deleted" : null}`}
     >
       <p>{comment.author}</p>
       <p>{comment.body}</p>
       <p>{comment.created_at}</p>
+      {signedInUser === comment.author ? (
+        <DeleteButton
+          comment_id={comment.comment_id}
+          isDeleted={isDeleted}
+          setIsDeleted={setIsDeleted}
+        />
+      ) : null}
     </li>
   );
 };

--- a/src/components/DeleteButton.js
+++ b/src/components/DeleteButton.js
@@ -1,0 +1,23 @@
+import { deleteComment } from "../utils/api";
+
+const DeleteButton = ({ comment_id, isDeleted, setIsDeleted }) => {
+  const handleClick = () => {
+    setIsDeleted(true);
+    deleteComment(comment_id).catch((err) => {
+      if (err) {
+        setIsDeleted(false);
+      }
+    });
+  };
+  return (
+    <button
+      className={`delete-button${isDeleted ? "-toggled" : null}`}
+      onClick={isDeleted ? null : handleClick}
+      disabled={isDeleted ? true : false}
+    >
+      {isDeleted ? "DELETED" : "DELETE"}
+    </button>
+  );
+};
+
+export default DeleteButton;

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -71,7 +71,7 @@ export const addCommentToArticleByID = (article_id, username, body) => {
 };
 
 export const deleteComment = (comment_id) => {
-  return ncNewsAPI.delete(`/comments/${comment_id}sdjfsdjf`).catch((err) => {
+  return ncNewsAPI.delete(`/comments/${comment_id}`).catch((err) => {
     if (err) {
       throw new Error("delete failed");
     }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -69,3 +69,11 @@ export const addCommentToArticleByID = (article_id, username, body) => {
       return response.data.addedComment;
     });
 };
+
+export const deleteComment = (comment_id) => {
+  return ncNewsAPI.delete(`/comments/${comment_id}sdjfsdjf`).catch((err) => {
+    if (err) {
+      throw new Error("delete failed");
+    }
+  });
+};


### PR DESCRIPTION
add delete button to comment cards
delete button only available to comments of logged in user
on click, reduces opacity of comment card and disables the button
if api error, comment it toggled back to normal